### PR TITLE
feat: add date type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Types design was inspired by [MobX State Tree](https://github.com/mobxjs/mobx-st
   - Codable
   - Optional
   - Array
-  - [TODO] Date
+  - Date
 
 ## Installation
 
@@ -39,10 +39,12 @@ npm install ts-codable
 
 ```ts
 import { BaseCodable, types, decode } from 'ts-codable';
+import dayjs from 'dayjs';
 
 class Post extends BaseCodable {
   title!: string;
   isActive?: boolean;
+  date!: Date;
 }
 
 Post.CodingProperties = {
@@ -51,6 +53,7 @@ Post.CodingProperties = {
     type: types.optional(types.boolean),
     key: 'active',
   },
+  date: types.date(dayjs),
 };
 
 class User extends BaseCodable {
@@ -72,10 +75,12 @@ const jsonPayload = {
     {
       title: 'dummy post',
       active: true,
+      date: '2020-02-15T16:00:00.000Z',
     },
     {
       title: 'deleted post',
       active: false,
+      date: '2020-02-10T16:00:00.000Z',
     },
   ],
 };
@@ -87,7 +92,6 @@ const user: User = decode(User, jsonPayload);
 
 - [x] Add [Swift Decodable](https://developer.apple.com/documentation/swift/decodable) functionality.
 - [ ] Add [Swift Encodable](https://developer.apple.com/documentation/swift/encodable) functionality.
-- [ ] Add `Date` type support.
 - [ ] Write API docs.
 
 ## Built With

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,5 +1,6 @@
 export * from './codable';
 
+export { date as dateType } from './types/date';
 export { string as stringType } from './types/string';
 export { number as numberType } from './types/number';
 export { boolean as booleanType } from './types/boolean';
@@ -7,6 +8,7 @@ export { array as arrayType } from './types/array';
 export { optional as optionalType } from './types/optional';
 export * from './types';
 
+export { date as dateModel } from './models/date';
 export { string as stringModel } from './models/string';
 export { number as numberModel } from './models/number';
 export { boolean as booleanModel } from './models/boolean';

--- a/src/models/boolean.ts
+++ b/src/models/boolean.ts
@@ -1,14 +1,13 @@
-import { IModel, errors } from '../internal';
+import { IModel, IType, errors } from '../internal';
 
-export const boolean = (): IModel => {
-  const $type = 'boolean';
+export const boolean = (type: IType): IModel => {
   const validate = (key: string, value: any) => {
     if (value === undefined) {
-      throw errors.missingValue(key, $type);
+      throw errors.missingValue(key, type.name);
     }
 
-    if (typeof value !== 'boolean') {
-      throw errors.wrongType(key, $type, typeof value);
+    if (typeof value !== type.name) {
+      throw errors.wrongType(key, type.name, typeof value);
     }
     return true;
   };

--- a/src/models/date.ts
+++ b/src/models/date.ts
@@ -1,0 +1,35 @@
+import { IModel, IType, stringType, numberType, errors } from '../internal';
+
+export const date = (type: IType): IModel => {
+  const validate = (key: string, value: any) => {
+    if (type.parser === undefined || type.parser === null) {
+      throw errors.missingParser(key, type.name);
+    }
+
+    if (value === undefined) {
+      throw errors.missingValue(key, type.name);
+    }
+
+    if (typeof value !== stringType.name && typeof value !== numberType.name) {
+      throw errors.wrongType(
+        key,
+        `${stringType.name} or ${numberType.name}`,
+        typeof value
+      );
+    }
+    return true;
+  };
+
+  const decode = (key: string, value: any) => {
+    try {
+      return type.parser!(value);
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  return {
+    validate,
+    decode,
+  };
+};

--- a/src/models/date.ts
+++ b/src/models/date.ts
@@ -24,7 +24,7 @@ export const date = (type: IType): IModel => {
     try {
       return type.parser!(value);
     } catch (error) {
-      throw error;
+      throw errors.failToParse(key, value, error.message || error);
     }
   };
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,4 +1,5 @@
 import {
+  dateModel,
   stringModel,
   numberModel,
   booleanModel,
@@ -8,6 +9,7 @@ import {
 } from '../internal';
 
 export const models: IModelDictionary = {
+  date: dateModel,
   string: stringModel,
   number: numberModel,
   boolean: booleanModel,

--- a/src/models/number.ts
+++ b/src/models/number.ts
@@ -1,14 +1,13 @@
-import { IModel, errors } from '../internal';
+import { IModel, IType, errors } from '../internal';
 
-export const number = (): IModel => {
-  const $type = 'number';
+export const number = (type: IType): IModel => {
   const validate = (key: string, value: any) => {
     if (value === undefined) {
-      throw errors.missingValue(key, $type);
+      throw errors.missingValue(key, type.name);
     }
 
-    if (typeof value !== 'number') {
-      throw errors.wrongType(key, $type, typeof value);
+    if (typeof value !== type.name) {
+      throw errors.wrongType(key, type.name, typeof value);
     }
     return true;
   };

--- a/src/models/optional.ts
+++ b/src/models/optional.ts
@@ -3,23 +3,21 @@ import {
   isCodable,
   IModel,
   IType,
-  ISubType,
   decodeValue,
   errors,
 } from '../internal';
 
-export const optional = (subType?: ISubType): IModel => {
-  const $type = 'optional';
+export const optional = (type: IType): IModel => {
   const validate = (key: string, value: any) => {
-    if (subType === undefined) {
-      throw errors.missingSubType(key, $type);
+    if (type.subtype === undefined) {
+      throw errors.missingSubType(key, type.name);
     }
 
     if (value === undefined) {
       return true;
     }
 
-    if (isCodable(subType)) {
+    if (isCodable(type.subtype)) {
       /**
        * @DEV | while decoding `Codable` it will validate it self.
        */
@@ -27,20 +25,27 @@ export const optional = (subType?: ISubType): IModel => {
     }
 
     if (
-      (subType as IType).name !== undefined &&
-      (subType as IType).name === 'optional'
+      (type.subtype as IType).name !== undefined &&
+      (type.subtype as IType).name === type.name
     ) {
-      throw errors.subTypeNotSupported(key, $type, (subType as IType).name);
+      throw errors.subTypeNotSupported(
+        key,
+        type.name,
+        (type.subtype as IType).name
+      );
     }
 
-    return models[(subType as IType).name]().validate(key, value);
+    return models[(type.subtype as IType).name](type.subtype).validate(
+      key,
+      value
+    );
   };
 
   const decode = (key: string, value: object) =>
     value === undefined
       ? undefined
       : validate(key, value)
-      ? decodeValue(key, subType!, value)
+      ? decodeValue(key, type.subtype!, value)
       : undefined;
 
   return {

--- a/src/models/string.ts
+++ b/src/models/string.ts
@@ -1,14 +1,13 @@
-import { IModel, errors } from '../internal';
+import { IModel, IType, errors } from '../internal';
 
-export const string = (): IModel => {
-  const $type = 'string';
+export const string = (type: IType): IModel => {
   const validate = (key: string, value: any) => {
     if (value === undefined) {
-      throw errors.missingValue(key, $type);
+      throw errors.missingValue(key, type.name);
     }
 
-    if (typeof value !== 'string') {
-      throw errors.wrongType(key, $type, typeof value);
+    if (typeof value !== type.name) {
+      throw errors.wrongType(key, type.name, typeof value);
     }
     return true;
   };

--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -1,0 +1,6 @@
+import { IType, IDateParser } from '../internal';
+
+export const date = (parser: IDateParser): IType => ({
+  name: 'date',
+  parser,
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import {
+  dateType,
   stringType,
   numberType,
   booleanType,
@@ -7,6 +8,7 @@ import {
 } from '../internal';
 
 export const types = {
+  date: dateType,
   string: stringType,
   number: numberType,
   boolean: booleanType,

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -67,6 +67,6 @@ export const decodeValue = (
     return decodeCodable(type, value, false);
   }
 
-  const model: IModel = models[type.name](type.subtype);
+  const model: IModel = models[type.name](type);
   return model.validate(key, value) ? model.decode(key, value) : undefined;
 };

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,4 +7,6 @@ export const errors = {
     `Value found with a wrong type. key: '${key}', expected type: '${expectedType}', found type: '${foundType}'`,
   subTypeNotSupported: (key: string, type: string, subType: string) =>
     `Subtype of a complex property is not supported. key: '${key}', type: ${type}, subtype: ${subType}`,
+  missingParser: (key: string, type: string) =>
+    `Missing date parser. key: '${key}', type: ${type}`,
 };

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -9,4 +9,6 @@ export const errors = {
     `Subtype of a complex property is not supported. key: '${key}', type: ${type}, subtype: ${subType}`,
   missingParser: (key: string, type: string) =>
     `Missing date parser. key: '${key}', type: ${type}`,
+  failToParse: (key: string, value: string, errorMessage: string) =>
+    `Fail to parse date with custom parser. key: '${key}', value: '${value}', parser error: '${errorMessage}'`,
 };

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -11,9 +11,12 @@ export type ICodingPropertyType = ICodingProperty | IType | ICodable;
 
 export type ISubType = IType | ICodable;
 
+export type IDateParser = (value: string | number) => Date;
+
 export interface IType {
   name: keyof typeof types;
   subtype?: ISubType;
+  parser?: IDateParser;
 }
 
 export interface IModel {
@@ -22,7 +25,7 @@ export interface IModel {
 }
 
 export type IModelDictionary = {
-  [key in keyof typeof types]: (subType?: ISubType) => IModel;
+  [key in keyof typeof types]: (type: IType) => IModel;
 };
 
 export type INewable<T> = new (...args: any[]) => T;

--- a/test/codable.test.ts
+++ b/test/codable.test.ts
@@ -516,4 +516,117 @@ describe('Decoder', () => {
       );
     });
   });
+
+  describe('Decode Date', () => {
+    it('decode property with date type', () => {
+      class Post extends BaseCodable {
+        createdAt!: Date;
+      }
+
+      const mockedDate = new Date(fixturePayload.createdAt);
+      const parser = (value: string | number) => new Date(value);
+
+      Post.CodingProperties = {
+        createdAt: types.date(parser),
+      };
+
+      const post = decode(Post, fixturePayload);
+      expect(post.createdAt).toMatchObject(mockedDate);
+    });
+
+    it('decode property with date type and custom key', () => {
+      class Post extends BaseCodable {
+        date!: Date;
+      }
+
+      const mockedDate = new Date(fixturePayload.createdAt);
+      const parser = (value: string | number) => new Date(value);
+
+      Post.CodingProperties = {
+        date: {
+          type: types.date(parser),
+          key: 'createdAt',
+        },
+      };
+
+      const post = decode(Post, fixturePayload);
+      expect(post.date).toMatchObject(mockedDate);
+    });
+
+    it('decode property with optional date type', () => {
+      class Post extends BaseCodable {
+        date?: Date;
+      }
+
+      const parser = (value: string | number) => new Date(value);
+
+      Post.CodingProperties = {
+        date: {
+          type: types.optional(types.date(parser)),
+          key: 'non-exist-key',
+        },
+      };
+
+      const post = decode(Post, fixturePayload);
+      expect(post.date).toBe(undefined);
+    });
+
+    it('throws error when decode a missing value a non-optional property', () => {
+      class Post extends BaseCodable {
+        date!: Date;
+      }
+
+      const mockedDate = new Date(fixturePayload.createdAt);
+      const parser = (value: string | number) => new Date(value);
+
+      Post.CodingProperties = {
+        date: {
+          type: types.date(parser),
+          key: 'non-exist-key',
+        },
+      };
+
+      expect(() => decode(Post, fixturePayload)).toThrowError(
+        /Missing value for a non optional property/
+      );
+    });
+
+    it('throws error when decode a wrong type', () => {
+      class Post extends BaseCodable {
+        date!: Date;
+      }
+
+      const parser = (value: string | number) => new Date(value);
+
+      Post.CodingProperties = {
+        date: {
+          type: types.date(parser),
+          key: 'active',
+        },
+      };
+
+      expect(() => decode(Post, fixturePayload)).toThrowError(
+        /Value found with a wrong type\. key: 'active', expected type: 'string or number', found type: 'boolean'/
+      );
+    });
+
+    it('throws error when decode an optional wrong type', () => {
+      class Post extends BaseCodable {
+        date!: Date;
+      }
+
+      const parser = (value: string | number) => new Date(value);
+
+      Post.CodingProperties = {
+        date: {
+          type: types.optional(types.date(parser)),
+          key: 'active',
+        },
+      };
+
+      expect(() => decode(Post, fixturePayload)).toThrowError(
+        /Value found with a wrong type. key: 'active', expected type: 'string or number', found type: 'boolean'/
+      );
+    });
+  });
 });

--- a/test/codable.test.ts
+++ b/test/codable.test.ts
@@ -610,6 +610,45 @@ describe('Decoder', () => {
       );
     });
 
+    it('throws error when not providing custom parser', () => {
+      class Post extends BaseCodable {
+        date!: Date;
+      }
+
+      Post.CodingProperties = {
+        date: {
+          // @ts-ignore
+          type: types.date(null),
+          key: 'createdAt',
+        },
+      };
+
+      expect(() => decode(Post, fixturePayload)).toThrowError(
+        /Missing date parser. key: 'createdAt', type: date/
+      );
+    });
+
+    it('throws error when custom parser fail to parse value', () => {
+      class Post extends BaseCodable {
+        date!: Date;
+      }
+
+      const parser = (value: string | number) => {
+        throw `Opss Error`;
+      };
+
+      Post.CodingProperties = {
+        date: {
+          type: types.date(parser),
+          key: 'title',
+        },
+      };
+
+      expect(() => decode(Post, fixturePayload)).toThrowError(
+        /Fail to parse date with custom parser. key: 'title', value: 'voluptate et itaque vero tempora molestiae', parser error: 'Opss Error'/
+      );
+    });
+
     it('throws error when decode an optional wrong type', () => {
       class Post extends BaseCodable {
         date!: Date;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -4,6 +4,8 @@ export const fixturePayload = {
   active: true,
   tags: ['voluptas', 'et', 'natus'],
   categories: [1, 2, 3],
+  createdAt: '2020-02-15T03:24:00',
+  updatedAt: 1581794160,
   user: {
     id: 1000,
     username: 'Gorhom',


### PR DESCRIPTION
added `Date` type support, with custom parser passed to coding properties

```ts
const customParser = (value: string | number): Date => parsedDate
types.date(customParser)
```